### PR TITLE
Spelling Correction, Three New Translations

### DIFF
--- a/src/main/resources/assets/bettercombat/lang/de_de.json
+++ b/src/main/resources/assets/bettercombat/lang/de_de.json
@@ -1,0 +1,21 @@
+{
+  "attribute.name.generic.attack_range" : "Reichweite",
+  "item.modifiers.two_handed": "Zweihändige",
+  "keybinds.bettercombat.feint" : "Finte",
+  "keybinds.bettercombat.toggle_mine_with_weapons" : "Schalten Sie den Bergbau mit Waffen um",
+
+  "config.bettercombat.clientConfig.isHoldToAttackEnabled" : "Halten um anzugreifen",
+  "config.bettercombat.clientConfig.isHoldToAttackEnabled.tooltip" : "Greife automatisch an, während du die Angriffstaste gedrückt hältst",
+  "config.bettercombat.clientConfig.isMiningWithWeaponsEnabled" : "Bergbau mit Waffen",
+  "config.bettercombat.clientConfig.isMiningWithWeaponsEnabled.tooltip" : "Bergbau mit Waffen zulassen",
+  "config.bettercombat.clientConfig.isSwingThruGrassEnabled" : "Angriff durch Gras",
+  "config.bettercombat.clientConfig.isSwingThruGrassEnabled.tooltip" : "Ermöglicht Waffen durch nicht feste Blöcke anzugreifen",
+  "config.bettercombat.clientConfig.isHighlightCrosshairEnabled" : "Fadenkreuz hervorheben",
+  "config.bettercombat.clientConfig.isHighlightCrosshairEnabled.tooltip" : "Hebt das Fadenkreuz hervor, das ein Feind nahe genug ist, um anzugreifen.\nWARNUNG: Die Aktivierung dieser Option kann die Leistung erheblich verlangsamen.",
+  "config.bettercombat.clientConfig.hudHighlightColor" : "Hervorhebungsfarbe",
+  "config.bettercombat.clientConfig.hudHighlightColor.tooltip" : "Farbe wird nach Bedarf auf UI-Elemente angewendet",
+  "config.bettercombat.clientConfig.isShowingArmsInFirstPerson": "Handsichtbarkeit im First-Person-Modus",
+  "config.bettercombat.clientConfig.isShowingArmsInFirstPerson.tooltip": "Rendern Sie Hände für Angriffsanimationen, die in der First-Person-Modus gespielt werden",
+  "config.bettercombat.clientConfig.isTooltipAttackRangeEnabled": "Gegenstands-Tooltip: Reichweite",
+  "config.bettercombat.clientConfig.isTooltipAttackRangeEnabled.tooltip": "Zeigt den Wert der Reichweite im Tooltip der Waffe"
+}

--- a/src/main/resources/assets/bettercombat/lang/en_us.json
+++ b/src/main/resources/assets/bettercombat/lang/en_us.json
@@ -8,7 +8,7 @@
   "config.bettercombat.clientConfig.isHoldToAttackEnabled.tooltip" : "Automatically attack while holding the attack button",
   "config.bettercombat.clientConfig.isMiningWithWeaponsEnabled" : "Mine with weapons",
   "config.bettercombat.clientConfig.isMiningWithWeaponsEnabled.tooltip" : "Allow mining with weapons",
-  "config.bettercombat.clientConfig.isSwingThruGrassEnabled" : "Swing thru grass",
+  "config.bettercombat.clientConfig.isSwingThruGrassEnabled" : "Swing through grass",
   "config.bettercombat.clientConfig.isSwingThruGrassEnabled.tooltip" : "Attack instead of mining zero hardness blocks with weapons",
   "config.bettercombat.clientConfig.isHighlightCrosshairEnabled" : "Highlight crosshair",
   "config.bettercombat.clientConfig.isHighlightCrosshairEnabled.tooltip" : "Highlights the crosshair if enemies are close enough to strike.\nWARNING! Enabling this might reduce frame rate significantly.",

--- a/src/main/resources/assets/bettercombat/lang/es_es.json
+++ b/src/main/resources/assets/bettercombat/lang/es_es.json
@@ -1,0 +1,21 @@
+{
+  "attribute.name.generic.attack_range" : "Alcance de golpe",
+  "item.modifiers.two_handed": "de dos manos",
+  "keybinds.bettercombat.feint" : "amagar",
+  "keybinds.bettercombat.toggle_mine_with_weapons" : "Alternar minando con armas",
+
+  "config.bettercombat.clientConfig.isHoldToAttackEnabled" : "Mantener para atacar",
+  "config.bettercombat.clientConfig.isHoldToAttackEnabled.tooltip" : "Ataca automáticamente mientras mantienes presionado el botón de ataque",
+  "config.bettercombat.clientConfig.isMiningWithWeaponsEnabled" : "Minar con armas",
+  "config.bettercombat.clientConfig.isMiningWithWeaponsEnabled.tooltip" : "Permite minar con armas",
+  "config.bettercombat.clientConfig.isSwingThruGrassEnabled" : "Ataque de hierba",
+  "config.bettercombat.clientConfig.isSwingThruGrassEnabled.tooltip" : "Permite que las armas ataquen a través de bloques no sólidos",
+  "config.bettercombat.clientConfig.isHighlightCrosshairEnabled" : "Resaltar retícula",
+  "config.bettercombat.clientConfig.isHighlightCrosshairEnabled.tooltip" : "Resalta la retícula un enemigo está lo suficientemente cerca para atacar.\nADVERTENCIA: Habilitar esta opción puede ralentizar significativamente el rendimiento.",
+  "config.bettercombat.clientConfig.hudHighlightColor" : "Color de resaltado",
+  "config.bettercombat.clientConfig.hudHighlightColor.tooltip" : "El color se aplica a los elementos de la interfaz de usuario según sea necesario",
+  "config.bettercombat.clientConfig.isShowingArmsInFirstPerson": "Visibilidad de manos en modo de primera persona",
+  "config.bettercombat.clientConfig.isShowingArmsInFirstPerson.tooltip": "Renderizar armas para animaciones de ataque reproducidas en vista en primera persona",
+  "config.bettercombat.clientConfig.isTooltipAttackRangeEnabled": "Tooltip del ítem: Alcance de golpe",
+  "config.bettercombat.clientConfig.isTooltipAttackRangeEnabled.tooltip": "Mostrar el valor del rango de ataque en la información sobre herramientas del arma"
+}

--- a/src/main/resources/assets/bettercombat/lang/es_es.json
+++ b/src/main/resources/assets/bettercombat/lang/es_es.json
@@ -8,7 +8,7 @@
   "config.bettercombat.clientConfig.isHoldToAttackEnabled.tooltip" : "Ataca automáticamente mientras mantienes presionado el botón de ataque",
   "config.bettercombat.clientConfig.isMiningWithWeaponsEnabled" : "Minar con armas",
   "config.bettercombat.clientConfig.isMiningWithWeaponsEnabled.tooltip" : "Permite minar con armas",
-  "config.bettercombat.clientConfig.isSwingThruGrassEnabled" : "Ataque de hierba",
+  "config.bettercombat.clientConfig.isSwingThruGrassEnabled" : "Ataque por hierba",
   "config.bettercombat.clientConfig.isSwingThruGrassEnabled.tooltip" : "Permite que las armas ataquen a través de bloques no sólidos",
   "config.bettercombat.clientConfig.isHighlightCrosshairEnabled" : "Resaltar retícula",
   "config.bettercombat.clientConfig.isHighlightCrosshairEnabled.tooltip" : "Resalta la retícula un enemigo está lo suficientemente cerca para atacar.\nADVERTENCIA: Habilitar esta opción puede ralentizar significativamente el rendimiento.",

--- a/src/main/resources/assets/bettercombat/lang/zh_cn.json
+++ b/src/main/resources/assets/bettercombat/lang/zh_cn.json
@@ -1,0 +1,21 @@
+{
+  "attribute.name.generic.attack_range" : "攻击范围",
+  "item.modifiers.two_handed": "双手武器",
+  "keybinds.bettercombat.feint" : "卖个破绽",
+  "keybinds.bettercombat.toggle_mine_with_weapons" : "切换使用武器进行采矿的能力",
+
+  "config.bettercombat.clientConfig.isHoldToAttackEnabled" : "按住按钮进行攻击",
+  "config.bettercombat.clientConfig.isHoldToAttackEnabled.tooltip" : "按住攻击键自动攻击",
+  "config.bettercombat.clientConfig.isMiningWithWeaponsEnabled" : "进行采矿武器",
+  "config.bettercombat.clientConfig.isMiningWithWeaponsEnabled.tooltip" : "允许使用武器开采方块",
+  "config.bettercombat.clientConfig.isSwingThruGrassEnabled" : "在草丛中挥舞武器",
+  "config.bettercombat.clientConfig.isSwingThruGrassEnabled.tooltip" : "攻击而不是用武器挖掘零硬度块",
+  "config.bettercombat.clientConfig.isHighlightCrosshairEnabled" : "凸显十字线",
+  "config.bettercombat.clientConfig.isHighlightCrosshairEnabled.tooltip" : "如果敌人足够近可以攻击，凸显示十字线。\n警告！ 启用此功能可能会显着降低帧速率。",
+  "config.bettercombat.clientConfig.hudHighlightColor" : "凸显颜色",
+  "config.bettercombat.clientConfig.hudHighlightColor.tooltip" : "应用于 HUD 元素的颜色（如果需要）",
+  "config.bettercombat.clientConfig.isShowingArmsInFirstPerson": "以第一人称视角显示手臂",
+  "config.bettercombat.clientConfig.isShowingArmsInFirstPerson.tooltip": "为在第一人称视图中播放的攻击动画渲染手臂",
+  "config.bettercombat.clientConfig.isTooltipAttackRangeEnabled": "项目工具提示: 攻击范围",
+  "config.bettercombat.clientConfig.isTooltipAttackRangeEnabled.tooltip": "在武器工具提示上显示攻击范围属性"
+}


### PR DESCRIPTION
There was a spelling error in the `en_us.json` file, so I corrected that. I also added translations for Simplified Chinese, Spanish and German. The German translation may need to be corrected at some point, as my German is quite antiquated, but it should suffice for making Better Combat more accessible. I'll work on more translations as time permits.