### PR TITLE
Simple NBT Logic

### DIFF
--- a/common/src/main/java/net/bettercombat/logic/WeaponRegistry.java
+++ b/common/src/main/java/net/bettercombat/logic/WeaponRegistry.java
@@ -14,7 +14,6 @@ import net.minecraft.network.PacketByteBuf;
 import net.minecraft.resource.ResourceManager;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.registry.Registry;
-import org.lwjgl.system.CallbackI;
 import org.slf4j.Logger;
 
 import java.io.InputStreamReader;

--- a/common/src/main/java/net/bettercombat/logic/WeaponRegistry.java
+++ b/common/src/main/java/net/bettercombat/logic/WeaponRegistry.java
@@ -14,6 +14,7 @@ import net.minecraft.network.PacketByteBuf;
 import net.minecraft.resource.ResourceManager;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.registry.Registry;
+import org.lwjgl.system.CallbackI;
 import org.slf4j.Logger;
 
 import java.io.InputStreamReader;
@@ -40,6 +41,13 @@ public class WeaponRegistry {
         if (itemStack == null) {
             return null;
         }
+        if(itemStack.hasNbt()){
+            String tag = itemStack.getNbt().getString("bettercombatparent");
+            if(tag!=null && !tag.equals("")){
+                WeaponAttributes attributes = WeaponRegistry.getAttributes(new Identifier(tag));
+                return attributes;
+            }
+        }
         Item item = itemStack.getItem();
         Identifier id = Registry.ITEM.getId(item);
         WeaponAttributes attributes = WeaponRegistry.getAttributes(id);
@@ -54,7 +62,7 @@ public class WeaponRegistry {
         // Resolving parents
         containers.forEach( (itemId, container) -> {
             if (!Registry.ITEM.containsId(itemId)) {
-                return;
+                //return;
             }
             resolveAndRegisterAttributes(itemId, container);
         });


### PR DESCRIPTION
Sorry if im annoying, but this would be a far simpler way to allow other mods to declare Weapons with NBT tags.
It now depends on the other mod setting up the right NBT tag instead of a complicated NBT detection System.

This would force Mods that want to register over NBT to set the NBT tag
"bettercombatparent" to the same value as the Parent in the Json would be set to.
This kinda requires to parse WeaponConfigurations of Weapons that dont exist so the Parent can be found and accessed properly.