### PR TITLE
ReplayMod Compat

### DIFF
--- a/common/src/main/java/net/bettercombat/client/ClientNetwork.java
+++ b/common/src/main/java/net/bettercombat/client/ClientNetwork.java
@@ -16,11 +16,13 @@ public class ClientNetwork {
             final var packet = Packets.AttackAnimation.read(buf);
             client.execute(() -> {
                 var entity = client.world.getEntityById(packet.playerId());
-                if (entity instanceof PlayerEntity) {
+                //This addition check is not required, ive tested without it,
+                //but it probably retriggers the animation and could lead to issues on servers with higher pings
+                if (entity instanceof PlayerEntity player && player != client.player) {
                     if (packet.animationName().equals(Packets.AttackAnimation.StopSymbol)) {
-                        ((PlayerAttackAnimatable)entity).stopAttackAnimation(packet.length());
+                        ((PlayerAttackAnimatable) entity).stopAttackAnimation(packet.length());
                     } else {
-                        ((PlayerAttackAnimatable)entity).playAttackAnimation(packet.animationName(), packet.animatedHand(), packet.length(), packet.upswing());
+                        ((PlayerAttackAnimatable) entity).playAttackAnimation(packet.animationName(), packet.animatedHand(), packet.length(), packet.upswing());
                     }
                 }
             });
@@ -36,7 +38,7 @@ public class ClientNetwork {
 
                     var soundEvent = Registries.SOUND_EVENT.get(new Identifier(packet.soundId()));
                     var configVolume = BetterCombatClient.config.weaponSwingSoundVolume;
-                    var volume = packet.volume() * ((float)Math.min(Math.max(configVolume, 0), 100) / 100F);
+                    var volume = packet.volume() * ((float) Math.min(Math.max(configVolume, 0), 100) / 100F);
                     client.world.playSound(
                             packet.x(),
                             packet.y(),


### PR DESCRIPTION
Changed Logic so Animation Paket is also send to the client it originated from. Clients now disregard Pakets about themselfs. This makes replaymod compatible since it simply records all Pakets the Client recieved.