### PR TITLE
1.19.2-compatible with replay mod.

### DIFF
--- a/common/src/main/java/net/bettercombat/client/ClientNetwork.java
+++ b/common/src/main/java/net/bettercombat/client/ClientNetwork.java
@@ -16,7 +16,7 @@ public class ClientNetwork {
             final var packet = Packets.AttackAnimation.read(buf);
             client.execute(() -> {
                 var entity = client.world.getEntityById(packet.playerId());
-                if (entity instanceof PlayerEntity) {
+                if (entity instanceof PlayerEntity && entity != MinecraftClient.getInstance().player) {
                     if (packet.animationName().equals(Packets.AttackAnimation.StopSymbol)) {
                         ((PlayerAttackAnimatable)entity).stopAttackAnimation(packet.length());
                     } else {

--- a/common/src/main/java/net/bettercombat/network/ServerNetwork.java
+++ b/common/src/main/java/net/bettercombat/network/ServerNetwork.java
@@ -71,7 +71,13 @@ public class ServerNetwork {
                 } catch (Exception e){
                     e.printStackTrace();
                 }
-            });
+            });//the provided entity is a player, it is not guaranteed by the contract that said player is included in the resulting stream.
+            Entity initiator = world.getEntityById(player.getId());
+            if (initiator instanceof ServerPlayerEntity){
+                if (ServerPlayNetworking.canSend((ServerPlayerEntity)initiator, Packets.AttackAnimation.ID)) {
+                    ServerPlayNetworking.send((ServerPlayerEntity)initiator, Packets.AttackAnimation.ID, forwardBuffer);
+                }
+            }
         });
 
         ServerPlayNetworking.registerGlobalReceiver(Packets.C2S_AttackRequest.ID, (server, player, handler, buf, responseSender) -> {


### PR DESCRIPTION
In single-player mode, the replay mod cannot record player actions because the replay mod only stores packets. Therefore, packets have been added for the client player. These packets do not affect the game in progress and only apply to the replay.