### PR TITLE
Nbt multiplayer fixes

### DIFF
--- a/common/src/main/java/net/bettercombat/client/ClientNetwork.java
+++ b/common/src/main/java/net/bettercombat/client/ClientNetwork.java
@@ -16,11 +16,13 @@ public class ClientNetwork {
             final var packet = Packets.AttackAnimation.read(buf);
             client.execute(() -> {
                 var entity = client.world.getEntityById(packet.playerId());
-                if (entity instanceof PlayerEntity) {
+                //This addition check is not required, ive tested without it,
+                //but it probably retriggers the animation and could lead to issues on servers with higher pings
+                if (entity instanceof PlayerEntity player && player != client.player) {
                     if (packet.animationName().equals(Packets.AttackAnimation.StopSymbol)) {
-                        ((PlayerAttackAnimatable)entity).stopAttackAnimation(packet.length());
+                        ((PlayerAttackAnimatable) entity).stopAttackAnimation(packet.length());
                     } else {
-                        ((PlayerAttackAnimatable)entity).playAttackAnimation(packet.animationName(), packet.animatedHand(), packet.length(), packet.upswing());
+                        ((PlayerAttackAnimatable) entity).playAttackAnimation(packet.animationName(), packet.animatedHand(), packet.length(), packet.upswing());
                     }
                 }
             });
@@ -36,7 +38,7 @@ public class ClientNetwork {
 
                     var soundEvent = Registries.SOUND_EVENT.get(new Identifier(packet.soundId()));
                     var configVolume = BetterCombatClient.config.weaponSwingSoundVolume;
-                    var volume = packet.volume() * ((float)Math.min(Math.max(configVolume, 0), 100) / 100F);
+                    var volume = packet.volume() * ((float) Math.min(Math.max(configVolume, 0), 100) / 100F);
                     client.world.playSound(
                             packet.x(),
                             packet.y(),


### PR DESCRIPTION
so, this is a weird one.
NBT based properties are fully broken on servers.
This is because Attribute Containers were never synced to the client, only the finished WeaponAttributes
This means a player that never joined single player has no Attribute Container and this client is unable to locally resolve the nbt correctly.
To replicate this issue, simply open a server, start the client fresh, dont join single player, join directly a server and use
`/give @p minecraft:wooden_sword{weapon_attributes:'{"parent":"bettercombat:claymore"}'} 1`
This wooden sword wont have any animations.
If one enters singleplayer and then back to the server the same sword will work.

This PR fixes this issue by also syncing the Attribute Container in the same packet as the Weapon Attributes.