### PR TITLE
An attemp to update to 1.20.6

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,10 +34,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up JDK 17
+    - name: Set up JDK 21
       uses: actions/setup-java@v3
       with:
-        java-version: '17'
+        java-version: '21'
         distribution: 'temurin'
     - name: Build with Gradle
       uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <div align="center">
 
-  <a href="">![Java 17](https://img.shields.io/badge/Java%2017-ee9258?logo=coffeescript&logoColor=ffffff&labelColor=606060&style=flat-square)</a>
+  <a href="">![Java 21](https://img.shields.io/badge/Java%2021-ee9258?logo=coffeescript&logoColor=ffffff&labelColor=606060&style=flat-square)</a>
   <a href="">![Environment: Client & Server](https://img.shields.io/badge/environment-Client%20&%20Server-1976d2?style=flat-square)</a>
   <a href="">[![Discord](https://img.shields.io/discord/973561601519149057.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2&style=flat-square)](https://discord.gg/KN9b3pjFTM)</a>
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
 
 plugins {
     id "architectury-plugin" version "3.4-SNAPSHOT"
-    id "dev.architectury.loom" version "1.5-SNAPSHOT" apply false
+    id "dev.architectury.loom" version "1.6-SNAPSHOT" apply false
     id "org.cadixdev.licenser" version "0.6.1"
     id "io.github.juuxel.loom-quiltflower" version "1.7.+" apply false
     id "me.shedaniel.unified-publishing" version "0.1.+" apply false
@@ -43,7 +43,7 @@ allprojects {
 
     tasks.withType(JavaCompile) {
         options.encoding = "UTF-8"
-        options.release.set 17
+        options.release.set 21
     }
 
     java {

--- a/common/src/main/resources/bettercombat.mixins.json
+++ b/common/src/main/resources/bettercombat.mixins.json
@@ -2,7 +2,7 @@
   "required": true,
   "minVersion": "0.8",
   "package": "net.bettercombat.mixin",
-  "compatibilityLevel": "JAVA_17",
+  "compatibilityLevel": "JAVA_21",
   "mixins": [
     "EnchantmentMixin",
     "ItemStackMixin",

--- a/fabric/src/main/resources/bettercombat-fabric.mixins.json
+++ b/fabric/src/main/resources/bettercombat-fabric.mixins.json
@@ -2,7 +2,7 @@
   "required": true,
   "minVersion": "0.8",
   "package": "net.bettercombat.fabric.mixin",
-  "compatibilityLevel": "JAVA_17",
+  "compatibilityLevel": "JAVA_21",
   "mixins": [
   ],
   "client": [

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -33,10 +33,10 @@
     "bettercombat-fabric.mixins.json"
   ],
   "depends": {
-    "minecraft": ">=1.20.0",
-    "fabricloader": ">=0.14.0",
+    "minecraft": ">=1.20.5",
+    "fabricloader": ">=0.15.10",
     "fabric-api": "*",
-    "cloth-config": ">=11.0.0",
+    "cloth-config": ">=14.0.126",
     "player-animator": ">=1.0.0"
   },
   "breaks": {

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,13 +6,14 @@ org.gradle.daemon=false
 platforms=fabric,forge
 
 # Game
-minecraft_version=1.20.4
-yarn_mappings=1.20.4+build.3
+minecraft_version=1.20.6
+yarn_mappings=1.20.6+build.1
 
 # Loader
-fabric_version=0.95.4+1.20.4
-loader_version=0.15.6
-forge_version=49.0.27
+fabric_version=0.97.8+1.20.6
+loader_version=0.15.10
+# TODO: Currently, the latest version of forge doesn't support 1.20.6, update the mod for forge later
+forge_version=49.0.49
 
 # Mod Properties
 mod_version=1.8.6
@@ -20,13 +21,13 @@ maven_group=net
 archives_base_name=bettercombat
 
 # Dependencies
-cloth_config_version=13.0.121
+cloth_config_version=14.0.126
 player_anim_version=1.0.2-rc1+1.20.4
 tiny_config_version=2.3.2
 
 # Compatibility
-mod_menu_version=9.0.0
+mod_menu_version=10.0.0-beta.1
 #https://modrinth.com/mod/first-person-model/version/evkvoubL = 2.2.3-1.20
 fpm_version=evkvoubL
-spell_engine_version=0.12.5+1.20.1
+spell_engine_version=0.14.3+1.20.1
 mixin_extras_version=0.3.5

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,11 +7,12 @@ pluginManagement {
     }
 }
 
-if (JavaVersion.current().ordinal() + 1 < 17) {
-    throw new IllegalStateException("Please run gradle with Java 17+!")
+if (JavaVersion.current().ordinal() + 1 < 21) {
+    throw new IllegalStateException("Please run gradle with Java 21+!")
 }
 
 include("common")
 include("fabric")
-include("forge")
+// TODO: Forge doesn't support 1.20.6 as result will cause build failure, temporarily disable forge, add it back later
+//include("forge")
 rootProject.name = "bettercombat"


### PR DESCRIPTION
I sent a [PR](https://github.com/ZsoltMolnarrr/BetterCombat/pull/332) for updating to 1.20.4, and it seems to be working, but this require more work because of more breaking changes

The goal of this PR is to update the mod so it works with 1.20.5 since there are some breaking changes
I will try to update it with care, so when I require java 21 as minimum because of 1.20.5, it's also updated in `README.md`, in GitHub CI, and also in all the other places

if there is something I'm not sure about or something doesn't look right (**Unreachable code** that is already before this update for example) I will always leave a `TODO` so we can look to them later

For now forge doesn't support 1.20.5/6 so to not cause build failure I temporarily disable it, also player animator  dependency mod (I might send a PR right after this) has not updated to 1.20.5 yet

This PR might be closed and never finished since I'm not familiar with the Minecraft Apis and also not with this repository. Player animator dependency has not been updated to 1.20.5/6 yet