### PR TITLE
Changed swingthurgrass to allow for players to break "grass" with a weapon when there are no targets in range

### DIFF
--- a/common/src/main/java/net/bettercombat/mixin/client/MinecraftClientInject.java
+++ b/common/src/main/java/net/bettercombat/mixin/client/MinecraftClientInject.java
@@ -203,6 +203,21 @@ public abstract class MinecraftClientInject implements MinecraftClient_BetterCom
         if(!BetterCombatClient.config.isSwingThruGrassEnabled) {
             return false;
         }
+
+        var hand = getCurrentHand();
+        if (hand == null) return true;
+        var attack = hand.attack();
+        var cursorTarget = getCursorTarget();
+
+        List<Entity> targets = TargetFinder.findAttackTargets(
+                player,
+                cursorTarget,
+                attack,
+                hand.attributes().attackRange());
+
+        // allows for players to break "grass" with a weapon when there are no targets in range
+        if (targets.isEmpty()) return false;
+
         var regex = BetterCombatClient.config.swingThruGrassBlacklist;
         if (regex == null || regex.isEmpty()) {
             return true;


### PR DESCRIPTION
I find myself holding weapon a lot and trying to clear torches is vert annoying with better combat, especially when all tools are tagged as weapons, where I have to switch to some random item to break torches. I think change this makes much sense than always or never swinging through grass. I can also make this another config if you want.