### PR TITLE
fix: updating to 1.21.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,7 @@ forge/run/
 *.blend1
 example/src/main/resources/data/mcdw/
 example/src/main/resources/data/gate*
+common/bin
+fabric/bin
+neoforge/bin
+.vscode

--- a/common/src/main/java/net/bettercombat/client/animation/modifier/HarshAdjustmentModifier.java
+++ b/common/src/main/java/net/bettercombat/client/animation/modifier/HarshAdjustmentModifier.java
@@ -1,5 +1,6 @@
 package net.bettercombat.client.animation.modifier;
 
+import dev.kosmx.playerAnim.api.PartKey;
 import dev.kosmx.playerAnim.api.TransformType;
 import dev.kosmx.playerAnim.api.layered.modifier.AdjustmentModifier;
 import dev.kosmx.playerAnim.core.util.Vec3f;
@@ -8,7 +9,7 @@ import java.util.Optional;
 import java.util.function.Function;
 
 public class HarshAdjustmentModifier extends AdjustmentModifier {
-    public HarshAdjustmentModifier(Function<String, Optional<PartModifier>> source) {
+    public HarshAdjustmentModifier(Function<PartKey, Optional<PartModifier>> source) {
         super(source);
     }
 

--- a/common/src/main/java/net/bettercombat/logic/EntityAttributeHelper.java
+++ b/common/src/main/java/net/bettercombat/logic/EntityAttributeHelper.java
@@ -9,7 +9,7 @@ public class EntityAttributeHelper {
         var attributeModifiers = stack.get(DataComponentTypes.ATTRIBUTE_MODIFIERS);
         if (attributeModifiers != null) {
             for(var modifier: attributeModifiers.modifiers()) {
-                if (modifier.attribute().value().equals(EntityAttributes.PLAYER_ENTITY_INTERACTION_RANGE.value())) {
+                if (modifier.attribute().value().equals(EntityAttributes.ENTITY_INTERACTION_RANGE.value())) {
                     return true;
                 }
             }
@@ -22,7 +22,7 @@ public class EntityAttributeHelper {
         if (attributeModifiers != null) {
             int count = 0;
             for(var modifier: attributeModifiers.modifiers()) {
-                if (modifier.attribute().value().equals(EntityAttributes.PLAYER_ENTITY_INTERACTION_RANGE.value())) {
+                if (modifier.attribute().value().equals(EntityAttributes.ENTITY_INTERACTION_RANGE.value())) {
                     count += 1;
                 }
             }

--- a/common/src/main/java/net/bettercombat/logic/PlayerAttackHelper.java
+++ b/common/src/main/java/net/bettercombat/logic/PlayerAttackHelper.java
@@ -232,11 +232,11 @@ public class PlayerAttackHelper {
 
     public static double getStaticRange(PlayerEntity player, ItemStack stack) {
         var attributes = WeaponRegistry.getAttributes(stack);
-        return combineAttackRange(attributes, player.getAttributeBaseValue(EntityAttributes.PLAYER_ENTITY_INTERACTION_RANGE));
+        return combineAttackRange(attributes, player.getAttributeBaseValue(EntityAttributes.ENTITY_INTERACTION_RANGE));
     }
 
     public static double getRangeForItem(PlayerEntity player, ItemStack stack) {
-        var interactionRangeValue = player.getAttributeValue(EntityAttributes.PLAYER_ENTITY_INTERACTION_RANGE);
+        var interactionRangeValue = player.getAttributeValue(EntityAttributes.ENTITY_INTERACTION_RANGE);
         return getRangeWithItem(stack, interactionRangeValue);
     }
 

--- a/common/src/main/java/net/bettercombat/logic/WeaponAttributesFallback.java
+++ b/common/src/main/java/net/bettercombat/logic/WeaponAttributesFallback.java
@@ -4,8 +4,6 @@ import net.bettercombat.BetterCombatMod;
 import net.bettercombat.config.FallbackConfig;
 import net.bettercombat.utils.PatternMatching;
 import net.minecraft.component.DataComponentTypes;
-import net.minecraft.component.type.AttributeModifiersComponent;
-import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.entity.attribute.EntityAttribute;
 import net.minecraft.entity.attribute.EntityAttributes;
 import net.minecraft.item.Item;
@@ -24,7 +22,7 @@ public class WeaponAttributesFallback {
                 continue;
             }
             FallbackConfig.CompatibilitySpecifier[] specifiers = null;
-            if (hasAttributeModifier(item, EntityAttributes.GENERIC_ATTACK_DAMAGE)) {
+            if (hasAttributeModifier(item, EntityAttributes.ATTACK_DAMAGE)) {
                 specifiers = config.fallback_compatibility;
             } else if (item instanceof RangedWeaponItem) {
                 specifiers = config.ranged_weapons;

--- a/common/src/main/java/net/bettercombat/mixin/client/AbstractClientPlayerEntityMixin.java
+++ b/common/src/main/java/net/bettercombat/mixin/client/AbstractClientPlayerEntityMixin.java
@@ -1,6 +1,7 @@
 package net.bettercombat.mixin.client;
 
 import com.mojang.authlib.GameProfile;
+import dev.kosmx.playerAnim.api.PartKey;
 import dev.kosmx.playerAnim.api.firstPerson.FirstPersonConfiguration;
 import dev.kosmx.playerAnim.api.firstPerson.FirstPersonMode;
 import dev.kosmx.playerAnim.api.layered.IAnimation;
@@ -80,7 +81,7 @@ public abstract class AbstractClientPlayerEntityMixin extends PlayerEntity imple
                 || player.isSwimming()
                 || player.isUsingItem()
                 || player.isClimbing()
-                || player.isFallFlying()
+                // || player.isFallFlying()
                 || Platform.isCastingSpell(player)
                 || CrossbowItem.isCharged(mainHandStack)) {
             mainHandBodyPose.setPose(null, isLeftHanded);
@@ -184,39 +185,22 @@ public abstract class AbstractClientPlayerEntityMixin extends PlayerEntity imple
             if (FirstPersonMode.isFirstPersonPass()) {
                 var pitch = player.getPitch();
                 pitch = (float) Math.toRadians(pitch);
-                switch (partName) {
-                    case "body" -> {
-                        rotationX -= pitch;
-                        if (pitch < 0) {
-                            var offset = Math.abs(Math.sin(pitch));
-                            offsetY += offset * 0.5;
-                            offsetZ -= offset;
-                        }
+                if (partName == PartKey.BODY) {
+                    rotationX -= pitch;
+                    if (pitch < 0) {
+                        var offset = Math.abs(Math.sin(pitch));
+                        offsetY += offset * 0.5;
+                        offsetZ -= offset;
                     }
-//                    case "rightArm", "leftArm" -> {
-//                        rotationX = pitch;
-//                    }
-                    default -> {
-                        return Optional.empty();
-                    }
-                }
+                // else if (isArm(partName)) rotationX = pitch;
+                } else return Optional.empty();
             } else {
                 var pitch = player.getPitch();
                 pitch = (float) Math.toRadians(pitch);
-                switch (partName) {
-                    case "body" -> {
-                        rotationX -= pitch * 0.75F;
-                    }
-                    case "rightArm", "leftArm" -> {
-                        rotationX += pitch * 0.25F;
-                    }
-                    case "rightLeg", "leftLeg" -> {
-                        rotationX -= pitch * 0.75;
-                    }
-                    default -> {
-                        return Optional.empty();
-                    }
-                }
+                if (partName == PartKey.BODY) rotationX -= pitch * 0.75F;
+                else if (isArm(partName)) rotationX += pitch * 0.25F;
+                else if (isLeg(partName)) rotationX -= pitch * 0.75;
+                else return Optional.empty();
             }
 
             return Optional.of(new AdjustmentModifier.PartModifier(
@@ -224,6 +208,14 @@ public abstract class AbstractClientPlayerEntityMixin extends PlayerEntity imple
                     new Vec3f(offsetX, offsetY, offsetZ))
             );
         });
+    }
+
+    private boolean isArm(PartKey partName) {
+        return partName == PartKey.RIGHT_ARM || partName == PartKey.LEFT_ARM;
+    }
+
+    private boolean isLeg(PartKey partName) {
+        return partName == PartKey.RIGHT_LEG || partName == PartKey.LEFT_LEG;
     }
 
     private AdjustmentModifier createPoseAdjustment() {
@@ -237,16 +229,11 @@ public abstract class AbstractClientPlayerEntityMixin extends PlayerEntity imple
             float offsetZ = 0;
 
             if (!FirstPersonMode.isFirstPersonPass()) {
-                switch (partName) {
-                    case "rightArm", "leftArm" -> {
-                        if (!mainHandItemPose.lastAnimationUsesBodyChannel && player.isInSneakingPose()) {
-                            offsetY += 3;
-                        }
+                if (isArm(partName)) {
+                    if (!mainHandItemPose.lastAnimationUsesBodyChannel && player.isInSneakingPose()) {
+                        offsetY += 3;
                     }
-                    default -> {
-                        return Optional.empty();
-                    }
-                }
+                } else return Optional.empty();
             }
 
             return Optional.of(new AdjustmentModifier.PartModifier(
@@ -261,8 +248,8 @@ public abstract class AbstractClientPlayerEntityMixin extends PlayerEntity imple
         switch (pose) {
             case STANDING -> {
             }
-            case FALL_FLYING -> {
-            }
+            // case FALL_FLYING -> {
+            // }
             case SLEEPING -> {
             }
             case SWIMMING -> {
@@ -277,6 +264,7 @@ public abstract class AbstractClientPlayerEntityMixin extends PlayerEntity imple
             }
             case DYING -> {
             }
+			default -> {}
         }
         if (isMounting()) {
             StateCollectionHelper.configure(animation.rightLeg, false, false);

--- a/common/src/main/java/net/bettercombat/mixin/client/AbstractClientPlayerEntityMixin.java
+++ b/common/src/main/java/net/bettercombat/mixin/client/AbstractClientPlayerEntityMixin.java
@@ -81,7 +81,7 @@ public abstract class AbstractClientPlayerEntityMixin extends PlayerEntity imple
                 || player.isSwimming()
                 || player.isUsingItem()
                 || player.isClimbing()
-                // || player.isFallFlying()
+                || player.isGliding()
                 || Platform.isCastingSpell(player)
                 || CrossbowItem.isCharged(mainHandStack)) {
             mainHandBodyPose.setPose(null, isLeftHanded);
@@ -248,8 +248,8 @@ public abstract class AbstractClientPlayerEntityMixin extends PlayerEntity imple
         switch (pose) {
             case STANDING -> {
             }
-            // case FALL_FLYING -> {
-            // }
+            case GLIDING -> {
+            }
             case SLEEPING -> {
             }
             case SWIMMING -> {

--- a/common/src/main/java/net/bettercombat/mixin/client/ClientPlayerEntityMixin.java
+++ b/common/src/main/java/net/bettercombat/mixin/client/ClientPlayerEntityMixin.java
@@ -12,7 +12,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(ClientPlayerEntity.class)
 public class ClientPlayerEntityMixin {
-    @Inject(method = "tickMovement", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/input/Input;tick(ZF)V", shift = At.Shift.AFTER))
+    @Inject(method = "tickMovement", at = @At(value = "INVOKE", shift = At.Shift.AFTER))
     private void tickMovement_ModifyInput(CallbackInfo ci) {
         var config = BetterCombatMod.config;
         var multiplier = Math.min(Math.max(config.movement_speed_while_attacking, 0.0), 1.0);

--- a/common/src/main/java/net/bettercombat/mixin/client/ColliderDebugRenderer.java
+++ b/common/src/main/java/net/bettercombat/mixin/client/ColliderDebugRenderer.java
@@ -8,6 +8,8 @@ import net.bettercombat.client.collision.OrientedBoundingBox;
 import net.bettercombat.client.collision.TargetFinder;
 import net.bettercombat.logic.PlayerAttackHelper;
 import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gl.ShaderLoader.LoadException;
+import net.minecraft.client.gl.ShaderProgramKeys;
 import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.client.render.*;
 import net.minecraft.client.render.debug.DebugRenderer;
@@ -26,7 +28,7 @@ import java.util.stream.Collectors;
 @Mixin(DebugRenderer.class)
 public class ColliderDebugRenderer {
     @Inject(method = "render",at = @At("TAIL"))
-    public void renderColliderDebug(MatrixStack matrices, Frustum frustum, VertexConsumerProvider.Immediate vertexConsumers, double cameraX, double cameraY, double cameraZ, CallbackInfo ci) {
+    public void renderColliderDebug(MatrixStack matrices, Frustum frustum, VertexConsumerProvider.Immediate vertexConsumers, double cameraX, double cameraY, double cameraZ, CallbackInfo ci) throws LoadException {
         MinecraftClient client = MinecraftClient.getInstance();
         if (!((MinecraftClientAccessor) client).getEntityRenderDispatcher().shouldRenderHitboxes()) {
             return;
@@ -77,9 +79,9 @@ public class ColliderDebugRenderer {
         drawOutline(matrices, obb, collidingObbs, collides);
     }
 
-    private void drawOutline(MatrixStack matrixStack, OrientedBoundingBox obb, List<OrientedBoundingBox> otherObbs, boolean collides) {
+    private void drawOutline(MatrixStack matrixStack, OrientedBoundingBox obb, List<OrientedBoundingBox> otherObbs, boolean collides) throws LoadException {
         RenderSystem.enableDepthTest();
-        // RenderSystem.setShader(GameRenderer::getPositionColorProgram);
+        RenderSystem.setShader(MinecraftClient.getInstance().getShaderLoader().getProgramToLoad(ShaderProgramKeys.POSITION_COLOR));
         Tessellator tessellator = Tessellator.getInstance();
         BufferBuilder bufferBuilder = tessellator.begin(VertexFormat.DrawMode.DEBUG_LINE_STRIP, VertexFormats.POSITION_COLOR);
         RenderSystem.disableBlend();

--- a/common/src/main/java/net/bettercombat/mixin/client/ColliderDebugRenderer.java
+++ b/common/src/main/java/net/bettercombat/mixin/client/ColliderDebugRenderer.java
@@ -26,7 +26,7 @@ import java.util.stream.Collectors;
 @Mixin(DebugRenderer.class)
 public class ColliderDebugRenderer {
     @Inject(method = "render",at = @At("TAIL"))
-    public void renderColliderDebug(MatrixStack matrices, VertexConsumerProvider.Immediate vertexConsumers, double cameraX, double cameraY, double cameraZ, CallbackInfo ci) {
+    public void renderColliderDebug(MatrixStack matrices, Frustum frustum, VertexConsumerProvider.Immediate vertexConsumers, double cameraX, double cameraY, double cameraZ, CallbackInfo ci) {
         MinecraftClient client = MinecraftClient.getInstance();
         if (!((MinecraftClientAccessor) client).getEntityRenderDispatcher().shouldRenderHitboxes()) {
             return;
@@ -79,7 +79,7 @@ public class ColliderDebugRenderer {
 
     private void drawOutline(MatrixStack matrixStack, OrientedBoundingBox obb, List<OrientedBoundingBox> otherObbs, boolean collides) {
         RenderSystem.enableDepthTest();
-        RenderSystem.setShader(GameRenderer::getPositionColorProgram);
+        // RenderSystem.setShader(GameRenderer::getPositionColorProgram);
         Tessellator tessellator = Tessellator.getInstance();
         BufferBuilder bufferBuilder = tessellator.begin(VertexFormat.DrawMode.DEBUG_LINE_STRIP, VertexFormats.POSITION_COLOR);
         RenderSystem.disableBlend();

--- a/common/src/main/java/net/bettercombat/mixin/client/InGameHudInject.java
+++ b/common/src/main/java/net/bettercombat/mixin/client/InGameHudInject.java
@@ -15,7 +15,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(InGameHud.class)
 public abstract class InGameHudInject {
-    @Inject(method = "renderCrosshair", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/DrawContext;drawGuiTexture(Lnet/minecraft/util/Identifier;IIII)V"))
+    @Inject(method = "renderCrosshair", at = @At(value = "INVOKE"))
     private void pre_renderCrosshair(DrawContext context, RenderTickCounter tickCounter, CallbackInfo ci) {
         if (BetterCombatClientMod.config.isHighlightCrosshairEnabled) {
             setShaderForHighlighting();

--- a/common/src/main/java/net/bettercombat/mixin/client/ItemStackTooltipMixin.java
+++ b/common/src/main/java/net/bettercombat/mixin/client/ItemStackTooltipMixin.java
@@ -24,13 +24,13 @@ public class ItemStackTooltipMixin {
     private void appendAttributeModifierTooltip_BetterCombat_Range(Consumer<Text> textConsumer, PlayerEntity player,
                                                                    RegistryEntry<EntityAttribute> attribute, EntityAttributeModifier modifier, CallbackInfo ci) {
         if (BetterCombatClientMod.config.isTooltipAttackRangeReformat
-                && attribute.value() == EntityAttributes.PLAYER_ENTITY_INTERACTION_RANGE.value()
+                && attribute.value() == EntityAttributes.ENTITY_INTERACTION_RANGE.value()
                 && player != null) { // Even vanilla code checks for this
             var itemStack = (ItemStack) (Object) this;
             if (WeaponRegistry.getAttributes(itemStack) != null                     // Only for weapons
                     && EntityAttributeHelper.rangeModifierCount(itemStack) == 1) {  // Only if there is exactly one range modifier
                 ci.cancel();
-                var value = modifier.value() + player.getAttributeBaseValue(EntityAttributes.PLAYER_ENTITY_INTERACTION_RANGE);
+                var value = modifier.value() + player.getAttributeBaseValue(EntityAttributes.ENTITY_INTERACTION_RANGE);
                 textConsumer.accept(WeaponAttributeTooltip.attackRangeLine(value));
             }
         }

--- a/common/src/main/java/net/bettercombat/mixin/player/PlayerEntityMixin.java
+++ b/common/src/main/java/net/bettercombat/mixin/player/PlayerEntityMixin.java
@@ -133,7 +133,7 @@ public abstract class PlayerEntityMixin implements PlayerAttackProperties, Entit
                 this.dualWieldingAttributeMap = HashMultimap.create();
                 double multiplier = BetterCombatMod.config.dual_wielding_attack_speed_multiplier - 1;
                 dualWieldingAttributeMap.put(
-                        EntityAttributes.GENERIC_ATTACK_SPEED,
+                        EntityAttributes.ATTACK_SPEED,
                         new EntityAttributeModifier(
                                 dualWieldingSpeedModifierId,
                                 multiplier,

--- a/common/src/main/java/net/bettercombat/network/ServerNetwork.java
+++ b/common/src/main/java/net/bettercombat/network/ServerNetwork.java
@@ -107,7 +107,7 @@ public class ServerNetwork {
                         double multiplier = 0
                                 - (BetterCombatMod.config.reworked_sweeping_maximum_damage_penalty / BetterCombatMod.config.reworked_sweeping_extra_target_count)
                                 * Math.min(BetterCombatMod.config.reworked_sweeping_extra_target_count, request.entityIds().length - 1);
-                        var sweepRatio = player.getAttributeValue(EntityAttributes.PLAYER_SWEEPING_DAMAGE_RATIO);
+                        var sweepRatio = player.getAttributeValue(EntityAttributes.SWEEPING_DAMAGE_RATIO);
 
                         damageBaseMultiplier += multiplier + (BetterCombatMod.config.reworked_sweeping_maximum_damage_penalty * sweepRatio);
 
@@ -124,9 +124,9 @@ public class ServerNetwork {
 
                 Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> damageModifier = null;
                 if (damageBaseMultiplier != 0) {
-                    AttributeModifierHelper.fromModifier(EntityAttributes.GENERIC_ATTACK_DAMAGE, null);
+                    AttributeModifierHelper.fromModifier(EntityAttributes.ATTACK_DAMAGE, null);
                     damageModifier = AttributeModifierHelper.fromModifier(
-                            EntityAttributes.GENERIC_ATTACK_DAMAGE,
+                            EntityAttributes.ATTACK_DAMAGE,
                             new EntityAttributeModifier(TEMPORARY_ATTACK, damageBaseMultiplier, EntityAttributeModifier.Operation.ADD_MULTIPLIED_BASE));
                     player.getAttributes().addTemporaryModifiers(damageModifier);
                 }

--- a/fabric/src/main/java/net/bettercombat/fabric/client/FabricClientMod.java
+++ b/fabric/src/main/java/net/bettercombat/fabric/client/FabricClientMod.java
@@ -1,6 +1,6 @@
 package net.bettercombat.fabric.client;
 
-import net.bettercombat.BetterCombatMod;
+// import net.bettercombat.BetterCombatMod;
 import net.bettercombat.client.BetterCombatClientMod;
 import net.bettercombat.client.Keybindings;
 import net.bettercombat.client.WeaponAttributeTooltip;
@@ -8,8 +8,8 @@ import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientLifecycleEvents;
 import net.fabricmc.fabric.api.client.item.v1.ItemTooltipCallback;
 import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
-import net.minecraft.client.item.ModelPredicateProviderRegistry;
-import net.minecraft.util.Identifier;
+// import net.minecraft.client.item.ModelPredicateProviderRegistry;
+// import net.minecraft.util.Identifier;
 
 public class FabricClientMod implements ClientModInitializer {
     @Override
@@ -24,9 +24,9 @@ public class FabricClientMod implements ClientModInitializer {
         ItemTooltipCallback.EVENT.register((itemStack, context, type, lines) -> {
             WeaponAttributeTooltip.modifyTooltip(itemStack, lines);
         });
-        ModelPredicateProviderRegistry.register(Identifier.of(BetterCombatMod.ID, "loaded"), (stack, world, entity, seed) -> {
-            return 1.0F;
-        });
+        // ModelPredicateProviderRegistry.register(Identifier.of(BetterCombatMod.ID, "loaded"), (stack, world, entity, seed) -> {
+        //     return 1.0F;
+        // });
         FabricClientNetwork.init();
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,23 +8,23 @@ archives_name = bettercombat
 enabled_platforms = fabric,neoforge
 
 # Minecraft properties
-minecraft_version = 1.21.1
-yarn_mappings = 1.21.1+build.3
+minecraft_version = 1.21.4
+yarn_mappings=1.21.4+build.8
 
 # Dependencies
-fabric_loader_version = 0.16.5
-fabric_api_version = 0.103.0+1.21.1
-neoforge_version = 21.1.1
+fabric_loader_version = 0.16.10
+fabric_api_version = 0.118.0+1.21.4
+neoforge_version = 21.4.123
 yarn_mappings_patch_neoforge_version = 1.21+build.4
 
 mixin_extras_version=0.4.0
 tiny_config_version=2.3.2
 
-cloth_config_version=15.0.130
-player_anim_version=2.0.0-alpha1+1.21
+cloth_config_version=17.0.144
+player_anim_version=2.0.2+1.21.4
 
 # Compatibility
 mod_menu_version=11.0.0
 #https://modrinth.com/mod/first-person-model/version/evkvoubL = 2.2.3-1.20
-fpm_version=jD6JfmfQ
-spell_engine_version=0.12.5+1.20.1
+fpm_version=2.4.9
+spell_engine_version=1.6.0+1.21.1

--- a/neoforge/src/main/java/net/bettercombat/neoforge/client/NeoForgeClientMod.java
+++ b/neoforge/src/main/java/net/bettercombat/neoforge/client/NeoForgeClientMod.java
@@ -5,8 +5,8 @@ import net.bettercombat.BetterCombatMod;
 import net.bettercombat.client.BetterCombatClientMod;
 import net.bettercombat.client.Keybindings;
 import net.bettercombat.config.ClientConfigWrapper;
-import net.minecraft.client.item.ModelPredicateProviderRegistry;
-import net.minecraft.util.Identifier;
+// import net.minecraft.client.item.ModelPredicateProviderRegistry;
+// import net.minecraft.util.Identifier;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.ModLoadingContext;
@@ -27,9 +27,9 @@ public class NeoForgeClientMod {
         BetterCombatClientMod.init();
         BetterCombatClientMod.loadAnimation();
 
-        ModelPredicateProviderRegistry.registerGeneric(Identifier.of(BetterCombatMod.ID, "loaded"), (stack, world, entity, seed) -> {
-            return 1.0F;
-        });
+        // ModelPredicateProviderRegistry.registerGeneric(Identifier.of(BetterCombatMod.ID, "loaded"), (stack, world, entity, seed) -> {
+        //     return 1.0F;
+        // });
 
         ModLoadingContext.get().registerExtensionPoint(IConfigScreenFactory.class, () -> {
             return (IConfigScreenFactory) (modContainer, parent) -> AutoConfig.getConfigScreen(ClientConfigWrapper.class, parent).get();


### PR DESCRIPTION
Updating code to 1.21.4

Some of the now incompatible codes I couldn't find an equivalent yet.
These are the the parts I couldn't port and left commented:
* `|| player.isFallFlying()`and related case; **_(SOLVED)_**
  * Apparently isFallFlying was replaced by isGliding, according to [this doc](https://learn.microsoft.com/en-us/minecraft/creator/scriptapi/minecraft/server/player?view=minecraft-bedrock-stable)
* `RenderSystem.setShader(GameRenderer::getPositionColorProgram);` **_(MAYBE SOLVED)_**
  * Replaced it with `RenderSystem.setShader(MinecraftClient.getInstance().getShaderLoader().getProgramToLoad(ShaderProgramKeys.POSITION_COLOR));`. It seems right, I suppose, I need to try the mod on an older version to see if there's any difference, I don't think the sword hitbox is rendering right;
* `ModelPredicateProviderRegistry.register`;
  * I'm trying to figure out how to deal with this one, but it's being a pain. The removal of that class is not well documented (at least I haven't found it yet). The only quote about it I found for now was [here](https://github.com/orgs/FabricMC/discussions/4295). Looking up [here](https://wiki.fabricmc.net/tutorial:datagen_setup) to understand how to use it.
  * I'm not sure if this new API serves the previous purpose. I suppose it was used as a flag to know if the mod is loaded, maybe for some integration with other mods. If that's the case, to fix this one, I may need some guidance, as if it must be replaced with another thing, it may impact other mods.

I appreciate some caution with this PR, as it's my first contribution to Minecraft modding, so I may have gotten something wrong.