### PR TITLE
Add config for large interaction range scaling attack range

### DIFF
--- a/common/src/main/java/net/bettercombat/config/ServerConfig.java
+++ b/common/src/main/java/net/bettercombat/config/ServerConfig.java
@@ -113,4 +113,7 @@ public class ServerConfig implements ConfigData {
     public float getUpswingMultiplier() {
         return Math.max(0.2F, Math.min(1, upswing_multiplier));
     }
+    
+    @Comment("Interaction range beyond vanilla reach is multiplied by this value before being added to attack reach")
+    public float interactionRangeMultiplier = 1;
 }

--- a/common/src/main/java/net/bettercombat/logic/PlayerAttackHelper.java
+++ b/common/src/main/java/net/bettercombat/logic/PlayerAttackHelper.java
@@ -236,8 +236,16 @@ public class PlayerAttackHelper {
     }
 
     public static double getRangeForItem(PlayerEntity player, ItemStack stack) {
-        var interactionRangeValue = player.getAttributeValue(EntityAttributes.PLAYER_ENTITY_INTERACTION_RANGE);
-        return getRangeWithItem(stack, interactionRangeValue);
+        double interactionRangeValueBase = player.getAttributeBaseValue(EntityAttributes.PLAYER_ENTITY_INTERACTION_RANGE);
+        double interactionRangeValueActual = player.getAttributeValue(EntityAttributes.PLAYER_ENTITY_INTERACTION_RANGE);
+        if(interactionRangeValueActual > interactionRangeValueBase) {
+            double overflow = interactionRangeValueActual - interactionRangeValueBase;
+            overflow *= BetterCombatMod.config.interactionRangeMultiplier;
+            return interactionRangeValueBase + overflow;
+        } else {
+            //if actual reach is equal to or shorter than base reach
+            return interactionRangeValueActual;
+        }
     }
 
     public static double getRangeWithWeapon(PlayerEntity player, double interactionRangeValue) {

--- a/common/src/main/java/net/bettercombat/logic/PlayerAttackHelper.java
+++ b/common/src/main/java/net/bettercombat/logic/PlayerAttackHelper.java
@@ -11,6 +11,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.item.ShieldItem;
 
 import java.util.Arrays;
+import java.util.Objects;
 
 public class PlayerAttackHelper {
     public static float getDualWieldingAttackDamageMultiplier(PlayerEntity player, AttackHand hand) {
@@ -241,10 +242,10 @@ public class PlayerAttackHelper {
         if(interactionRangeValueActual > interactionRangeValueBase) {
             double overflow = interactionRangeValueActual - interactionRangeValueBase;
             overflow *= BetterCombatMod.config.interactionRangeMultiplier;
-            return interactionRangeValueBase + overflow;
+            return getRangeWithItem(stack,interactionRangeValueBase + overflow);
         } else {
             //if actual reach is equal to or shorter than base reach
-            return interactionRangeValueActual;
+            return getRangeWithItem(stack, interactionRangeValueActual);
         }
     }
 


### PR DESCRIPTION
Add config for how much additional interaction range effects weapon range

ex: if the player equips an item that gives them +10 interaction range, the +10 will be multiplied by the value set in the config when applying it to attack reach. The base value of 3 as well as the range modifiers of weapons are left alone.

If the player has an interaction range below their base range, it will not be modified.