### PR TITLE
FTB Teams integration into TargetHelper#getRelation

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -15,6 +15,17 @@ repositories {
             includeGroup 'maven.modrinth'
         }
     }
+    exclusiveContent {
+        forRepository {
+            maven {
+                url = "https://maven.ftb.dev/releases"
+            }
+        }
+        filter {
+            includeGroup"dev.latvian.mods"
+            includeGroup"dev.ftb.mods"
+        }
+    }
 }
 
 dependencies {
@@ -34,4 +45,7 @@ dependencies {
 
     modCompileOnly("com.terraformersmc:modmenu:${rootProject.mod_menu_version}") { transitive false }
     modCompileOnly("maven.modrinth:first-person-model:${project.fpm_version}")
+
+    modCompileOnly("dev.ftb.mods:ftb-teams:${project.ftb_teams_version}")
+    modCompileOnly("dev.ftb.mods:ftb-library:${project.ftb_library_version}")
 }

--- a/common/src/main/java/net/bettercombat/logic/TargetHelper.java
+++ b/common/src/main/java/net/bettercombat/logic/TargetHelper.java
@@ -1,6 +1,9 @@
 package net.bettercombat.logic;
 
+import dev.ftb.mods.ftbteams.api.FTBTeamsAPI;
+import dev.ftb.mods.ftbteams.api.TeamManager;
 import net.bettercombat.BetterCombatMod;
+import net.bettercombat.Platform;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.Tameable;
@@ -47,7 +50,22 @@ public class TargetHelper {
         }
         var attackerTeam = attacker.getScoreboardTeam();
         var targetTeam = target.getScoreboardTeam();
+
         if (attackerTeam == null || targetTeam == null) {
+            // --- FTB TEAMS ---
+            if (Platform.isModLoaded("ftbteams") && target instanceof PlayerEntity targetPlayer) {
+                boolean managerAvailable = attacker.getWorld().isClient ?
+                        FTBTeamsAPI.api().isClientManagerLoaded() :
+                        FTBTeamsAPI.api().isManagerLoaded();
+                if (managerAvailable) {
+                    TeamManager manager = FTBTeamsAPI.api().getManager();
+                    if (manager.arePlayersInSameTeam(attacker.getUuid(), targetPlayer.getUuid())) {
+                        return Relation.FRIENDLY;
+                    }
+                }
+            }
+            // --- END FTB TEAMS ---
+
             var targetTypeEntry = Registries.ENTITY_TYPE.getEntry(target.getType());
             var id = targetTypeEntry.getKey().get().getValue();
             var mappedRelation = config.player_relations.get(id.toString());

--- a/gradle.properties
+++ b/gradle.properties
@@ -28,3 +28,6 @@ mod_menu_version=11.0.0
 #https://modrinth.com/mod/first-person-model/version/evkvoubL = 2.2.3-1.20
 fpm_version=jD6JfmfQ
 spell_engine_version=0.12.5+1.20.1
+
+ftb_teams_version=2101.1.2
+ftb_library_version=2101.1.7


### PR DESCRIPTION
Also see: https://github.com/ZsoltMolnarrr/SpellEngine/pull/114

Return `FRIENDLY` if FTB Teams is loaded and the players are on the same FTB Team 

Should also work with the existing recursive Tameable check

*Note:*
FTB Teams does not seem to have a "friendly fire toggle" property I can find, so the check always returns friendly if players are on the same team.