### PR TITLE
Fix an NPE and solve the compatibility issue with SlashBlade Resharped

### DIFF
--- a/common/src/main/java/net/bettercombat/mixin/client/MinecraftClientInject.java
+++ b/common/src/main/java/net/bettercombat/mixin/client/MinecraftClientInject.java
@@ -314,6 +314,7 @@ public abstract class MinecraftClientInject implements MinecraftClient_BetterCom
     private void updateTargetsIfNeeded() {
         if (shouldUpdateTargetsInReach()) {
             var hand = PlayerAttackHelper.getCurrentAttack(player, getComboCount());
+            if (hand == null) return;
             WeaponAttributes attributes = WeaponRegistry.getAttributes(player.getMainHandStack());
             List<Entity> targets = List.of();
             if (attributes != null && attributes.attacks() != null) {


### PR DESCRIPTION
## Issue Overview
This issue leads to game crash like this https://mclo.gs/yyDHUIG when player put a [SlashBlade](https://www.curseforge.com/minecraft/mc-mods/slashblade-resharped) at the offhand slot and attack with any weapon.

In fact, this is just an easy null check. Just add this null check and it will work properly.

I have tested this patch at my machine. It does make the difference I described above before and after its presence.