### PR TITLE
Fix attack animation not playing with Yes Steve Model

### DIFF
--- a/common/src/main/java/net/bettercombat/mixin/client/MinecraftClientInject.java
+++ b/common/src/main/java/net/bettercombat/mixin/client/MinecraftClientInject.java
@@ -29,6 +29,7 @@ import net.minecraft.client.world.ClientWorld;
 import net.minecraft.entity.Entity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.registry.Registries;
+import net.minecraft.util.Hand;
 import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.util.hit.HitResult;
 import net.minecraft.util.math.BlockPos;
@@ -242,6 +243,9 @@ public abstract class MinecraftClientInject implements MinecraftClient_BetterCom
         }
 
         // Starting upswing
+        player.handSwingTicks = -1;
+        player.handSwinging = true;
+        player.preferredHand = hand.isOffHand() ? Hand.OFF_HAND : Hand.MAIN_HAND;
         player.stopUsingItem();
 
         lastAttacked = 0;


### PR DESCRIPTION
Yes Steve Model plays attack animation according to the `handSwinging` variable. Updating it in `startUpswing` makes the animation work properly.

Relevant issue: #385 

https://github.com/user-attachments/assets/d681339b-f75e-4b29-8a44-42964c0c2d08

