### PR TITLE
Migrate TrackedData usage to platform-specific Data Attachments 

### DIFF
--- a/common/src/main/java/net/bettercombat/PlayerAttachments.java
+++ b/common/src/main/java/net/bettercombat/PlayerAttachments.java
@@ -1,0 +1,51 @@
+package net.bettercombat;
+
+import dev.architectury.injectables.annotations.ExpectPlatform;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.util.Identifier;
+
+/**
+ * Platform-agnostic attachment helper for player idle animations.
+ * Defers to Fabric Data Attachments API or NeoForge Data Attachments
+ * Values are automatically synced to all clients.
+ * Values are not serialized/saved to disk
+ */
+public class PlayerAttachments {
+    public static final Identifier MAIN_HAND_IDLE_ANIMATION = Identifier.of("bettercombat", "main_hand_idle_animation");
+    public static final Identifier OFF_HAND_IDLE_ANIMATION = Identifier.of("bettercombat", "off_hand_idle_animation");
+
+    /**
+     * Gets the main hand idle animation string from the player's attachment.
+     * Returns empty string if not set.
+     */
+    @ExpectPlatform
+    public static String getMainHandIdleAnimation(PlayerEntity player) {
+        throw new AssertionError();
+    }
+
+    /**
+     * Gets the off hand idle animation string from the player's attachment.
+     * Returns empty string if not set.
+     */
+    @ExpectPlatform
+    public static String getOffHandIdleAnimation(PlayerEntity player) {
+        throw new AssertionError();
+    }
+
+    /**
+     * Sets the main hand idle animation string on the player's attachment.
+     */
+    @ExpectPlatform
+    public static void setMainHandIdleAnimation(PlayerEntity player, String animation) {
+        throw new AssertionError();
+    }
+
+    /**
+     * Sets the off hand idle animation string on the player's attachment.
+     */
+    @ExpectPlatform
+    public static void setOffHandIdleAnimation(PlayerEntity player, String animation) {
+        throw new AssertionError();
+    }
+}
+

--- a/common/src/main/java/net/bettercombat/mixin/player/PlayerEntityMixin.java
+++ b/common/src/main/java/net/bettercombat/mixin/player/PlayerEntityMixin.java
@@ -5,6 +5,7 @@ import com.google.common.collect.Multimap;
 import net.bettercombat.BetterCombatMod;
 import net.bettercombat.api.AttackHand;
 import net.bettercombat.api.EntityPlayer_BetterCombat;
+import net.bettercombat.PlayerAttachments;
 import net.bettercombat.client.animation.PlayerAttackAnimatable;
 import net.bettercombat.logic.PlayerAttackHelper;
 import net.bettercombat.logic.PlayerAttackProperties;
@@ -13,9 +14,6 @@ import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.entity.attribute.EntityAttribute;
 import net.minecraft.entity.attribute.EntityAttributeModifier;
 import net.minecraft.entity.attribute.EntityAttributes;
-import net.minecraft.entity.data.DataTracker;
-import net.minecraft.entity.data.TrackedData;
-import net.minecraft.entity.data.TrackedDataHandlerRegistry;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.registry.entry.RegistryEntry;
@@ -39,15 +37,6 @@ public abstract class PlayerEntityMixin implements PlayerAttackProperties, Entit
         this.comboCount = comboCount;
     }
 
-    private static final TrackedData<String> BETTER_COMBAT_MAIN_IDLE_ANIMATION = DataTracker.registerData(PlayerEntity.class, TrackedDataHandlerRegistry.STRING);
-    private static final TrackedData<String> BETTER_COMBAT_OFF_IDLE_ANIMATION = DataTracker.registerData(PlayerEntity.class, TrackedDataHandlerRegistry.STRING);
-
-    @Inject(method = "initDataTracker", at = @At("TAIL"))
-    private void initDataTracker_TAIL_SpellEngine_SyncEffects(DataTracker.Builder builder, CallbackInfo ci) {
-        builder.add(BETTER_COMBAT_MAIN_IDLE_ANIMATION, "");
-        builder.add(BETTER_COMBAT_OFF_IDLE_ANIMATION, "");
-    }
-
     @Inject(method = "tick", at = @At("TAIL"))
     public void post_Tick(CallbackInfo ci) {
         var instance = (Object)this;
@@ -57,18 +46,18 @@ public abstract class PlayerEntityMixin implements PlayerAttackProperties, Entit
             ((PlayerAttackAnimatable) this).updateAnimationsOnTick();
         } else {
             var pose = PlayerAttackHelper.poseForPlayer(player);
-            player.getDataTracker().set(BETTER_COMBAT_MAIN_IDLE_ANIMATION, pose.base());
-            player.getDataTracker().set(BETTER_COMBAT_OFF_IDLE_ANIMATION, pose.offHand());
+            PlayerAttachments.setMainHandIdleAnimation(player, pose.base());
+            PlayerAttachments.setOffHandIdleAnimation(player, pose.offHand());
         }
         updateDualWieldingSpeedBoost();
     }
 
     public String getMainHandIdleAnimation() {
-        return ((PlayerEntity) ((Object)this)).getDataTracker().get(BETTER_COMBAT_MAIN_IDLE_ANIMATION);
+        return PlayerAttachments.getMainHandIdleAnimation(((PlayerEntity) ((Object)this)));
     }
 
     public String getOffHandIdleAnimation() {
-        return ((PlayerEntity) ((Object)this)).getDataTracker().get(BETTER_COMBAT_OFF_IDLE_ANIMATION);
+        return PlayerAttachments.getOffHandIdleAnimation(((PlayerEntity) ((Object)this)));
     }
 
     // FEATURE: Disable sweeping for attributed weapons

--- a/fabric/src/main/java/net/bettercombat/fabric/FabricMod.java
+++ b/fabric/src/main/java/net/bettercombat/fabric/FabricMod.java
@@ -1,6 +1,7 @@
 package net.bettercombat.fabric;
 
 import net.bettercombat.BetterCombatMod;
+import net.bettercombat.fabric.attachment.FabricPlayerAttachments;
 import net.bettercombat.fabric.network.FabricServerNetwork;
 import net.bettercombat.particle.BetterCombatParticles;
 import net.bettercombat.utils.SoundHelper;
@@ -11,6 +12,8 @@ public class FabricMod implements ModInitializer {
     @Override
     public void onInitialize() {
         BetterCombatMod.init();
+        
+        FabricPlayerAttachments.init();
 
         ServerLifecycleEvents.SERVER_STARTING.register((minecraftServer) -> {
             BetterCombatMod.loadWeaponAttributes(minecraftServer);

--- a/fabric/src/main/java/net/bettercombat/fabric/PlayerAttachmentsImpl.java
+++ b/fabric/src/main/java/net/bettercombat/fabric/PlayerAttachmentsImpl.java
@@ -1,0 +1,23 @@
+package net.bettercombat.fabric;
+
+import net.bettercombat.fabric.attachment.FabricPlayerAttachments;
+import net.minecraft.entity.player.PlayerEntity;
+
+public class PlayerAttachmentsImpl {
+    public static String getMainHandIdleAnimation(PlayerEntity player) {
+        return FabricPlayerAttachments.getMainHandIdleAnimation(player);
+    }
+
+    public static String getOffHandIdleAnimation(PlayerEntity player) {
+        return FabricPlayerAttachments.getOffHandIdleAnimation(player);
+    }
+
+    public static void setMainHandIdleAnimation(PlayerEntity player, String animation) {
+        FabricPlayerAttachments.setMainHandIdleAnimation(player, animation);
+    }
+
+    public static void setOffHandIdleAnimation(PlayerEntity player, String animation) {
+        FabricPlayerAttachments.setOffHandIdleAnimation(player, animation);
+    }
+}
+

--- a/fabric/src/main/java/net/bettercombat/fabric/attachment/FabricPlayerAttachments.java
+++ b/fabric/src/main/java/net/bettercombat/fabric/attachment/FabricPlayerAttachments.java
@@ -1,0 +1,49 @@
+package net.bettercombat.fabric.attachment;
+
+import net.bettercombat.PlayerAttachments;
+import net.fabricmc.fabric.api.attachment.v1.AttachmentRegistry;
+import net.fabricmc.fabric.api.attachment.v1.AttachmentSyncPredicate;
+import net.fabricmc.fabric.api.attachment.v1.AttachmentType;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.network.codec.PacketCodecs;
+
+@SuppressWarnings("UnstableApiUsage")
+public class FabricPlayerAttachments {
+    private static AttachmentType<String> MAIN_HAND_IDLE_ANIMATION_TYPE;
+    private static AttachmentType<String> OFF_HAND_IDLE_ANIMATION_TYPE;
+
+    public static void init() {
+        // Register attachment types with default empty string values and syncing support
+        // Sync to all clients that can see the player (allButTarget syncs to other players, targetOnly syncs to the player themselves)
+        // We use all() to sync to everyone including the player themselves
+        MAIN_HAND_IDLE_ANIMATION_TYPE = AttachmentRegistry.create(
+                PlayerAttachments.MAIN_HAND_IDLE_ANIMATION,
+                builder -> builder
+                        .initializer(() -> "")
+                        .syncWith(PacketCodecs.STRING, AttachmentSyncPredicate.all())
+        );
+        OFF_HAND_IDLE_ANIMATION_TYPE = AttachmentRegistry.create(
+                PlayerAttachments.OFF_HAND_IDLE_ANIMATION,
+                builder -> builder
+                        .initializer(() -> "")
+                        .syncWith(PacketCodecs.STRING, AttachmentSyncPredicate.all())
+        );
+    }
+
+    public static String getMainHandIdleAnimation(PlayerEntity player) {
+        return player.getAttachedOrCreate(MAIN_HAND_IDLE_ANIMATION_TYPE);
+    }
+
+    public static String getOffHandIdleAnimation(PlayerEntity player) {
+        return player.getAttachedOrCreate(OFF_HAND_IDLE_ANIMATION_TYPE);
+    }
+
+    public static void setMainHandIdleAnimation(PlayerEntity player, String animation) {
+        player.setAttached(MAIN_HAND_IDLE_ANIMATION_TYPE, animation);
+    }
+
+    public static void setOffHandIdleAnimation(PlayerEntity player, String animation) {
+        player.setAttached(OFF_HAND_IDLE_ANIMATION_TYPE, animation);
+    }
+}
+

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,10 +12,10 @@ minecraft_version = 1.21.1
 yarn_mappings = 1.21.1+build.3
 
 # Dependencies
-fabric_loader_version = 0.16.5
-fabric_api_version = 0.103.0+1.21.1
-neoforge_version = 21.1.1
-yarn_mappings_patch_neoforge_version = 1.21+build.4
+fabric_loader_version = 0.18.1
+fabric_api_version = 0.116.7+1.21.1
+neoforge_version = 21.1.216
+yarn_mappings_patch_neoforge_version = 1.21+build.6
 
 mixin_extras_version=0.4.0
 tiny_config_version=2.3.2

--- a/neoforge/src/main/java/net/bettercombat/neoforge/NeoForgeMod.java
+++ b/neoforge/src/main/java/net/bettercombat/neoforge/NeoForgeMod.java
@@ -1,6 +1,7 @@
 package net.bettercombat.neoforge;
 
 import net.bettercombat.BetterCombatMod;
+import net.bettercombat.neoforge.attachment.NeoForgePlayerAttachments;
 import net.bettercombat.particle.BetterCombatParticles;
 import net.bettercombat.utils.SoundHelper;
 import net.minecraft.registry.Registries;
@@ -9,15 +10,24 @@ import net.minecraft.sound.SoundEvent;
 import net.minecraft.util.Identifier;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.fml.common.Mod;
+import net.neoforged.neoforge.attachment.AttachmentType;
 import net.neoforged.neoforge.registries.DeferredRegister;
+import net.neoforged.neoforge.registries.NeoForgeRegistries;
 import net.neoforged.neoforge.registries.RegisterEvent;
 
 @Mod(BetterCombatMod.ID)
 public final class NeoForgeMod {
+    public static final DeferredRegister<AttachmentType<?>> ATTACHMENT_TYPES =
+            DeferredRegister.create(NeoForgeRegistries.ATTACHMENT_TYPES, BetterCombatMod.ID);
+    
     public NeoForgeMod(IEventBus modEventBus) {
         BetterCombatMod.init();
+
+        NeoForgePlayerAttachments.init(ATTACHMENT_TYPES);
+        
         modEventBus.addListener(RegisterEvent.class, NeoForgeMod::register);
         SOUND_EVENTS.register(modEventBus);
+        ATTACHMENT_TYPES.register(modEventBus);
     }
 
     public static void register(RegisterEvent event) {

--- a/neoforge/src/main/java/net/bettercombat/neoforge/PlayerAttachmentsImpl.java
+++ b/neoforge/src/main/java/net/bettercombat/neoforge/PlayerAttachmentsImpl.java
@@ -1,0 +1,23 @@
+package net.bettercombat.neoforge;
+
+import net.bettercombat.neoforge.attachment.NeoForgePlayerAttachments;
+import net.minecraft.entity.player.PlayerEntity;
+
+public class PlayerAttachmentsImpl {
+    public static String getMainHandIdleAnimation(PlayerEntity player) {
+        return NeoForgePlayerAttachments.getMainHandIdleAnimation(player);
+    }
+
+    public static String getOffHandIdleAnimation(PlayerEntity player) {
+        return NeoForgePlayerAttachments.getOffHandIdleAnimation(player);
+    }
+
+    public static void setMainHandIdleAnimation(PlayerEntity player, String animation) {
+        NeoForgePlayerAttachments.setMainHandIdleAnimation(player, animation);
+    }
+
+    public static void setOffHandIdleAnimation(PlayerEntity player, String animation) {
+        NeoForgePlayerAttachments.setOffHandIdleAnimation(player, animation);
+    }
+}
+

--- a/neoforge/src/main/java/net/bettercombat/neoforge/attachment/NeoForgePlayerAttachments.java
+++ b/neoforge/src/main/java/net/bettercombat/neoforge/attachment/NeoForgePlayerAttachments.java
@@ -1,0 +1,43 @@
+package net.bettercombat.neoforge.attachment;
+
+import net.bettercombat.PlayerAttachments;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.network.codec.PacketCodecs;
+import net.neoforged.neoforge.attachment.AttachmentType;
+import net.neoforged.neoforge.registries.DeferredRegister;
+
+public class NeoForgePlayerAttachments {
+    private static AttachmentType<String> MAIN_HAND_IDLE_ANIMATION_TYPE;
+    private static AttachmentType<String> OFF_HAND_IDLE_ANIMATION_TYPE;
+
+    public static void init(DeferredRegister<AttachmentType<?>> attachmentTypes) {
+        // Register attachment types with serialization and syncing support
+        // Sync to all clients that can see the player
+        MAIN_HAND_IDLE_ANIMATION_TYPE = AttachmentType.builder(() -> "")
+                .sync(PacketCodecs.STRING)
+                .build();
+        OFF_HAND_IDLE_ANIMATION_TYPE = AttachmentType.builder(() -> "")
+                .sync(PacketCodecs.STRING)
+                .build();
+
+        attachmentTypes.register(PlayerAttachments.MAIN_HAND_IDLE_ANIMATION.getPath(), () -> MAIN_HAND_IDLE_ANIMATION_TYPE);
+        attachmentTypes.register(PlayerAttachments.OFF_HAND_IDLE_ANIMATION.getPath(), () -> OFF_HAND_IDLE_ANIMATION_TYPE);
+    }
+
+    public static String getMainHandIdleAnimation(PlayerEntity player) {
+        return player.getData(MAIN_HAND_IDLE_ANIMATION_TYPE);
+    }
+
+    public static String getOffHandIdleAnimation(PlayerEntity player) {
+        return player.getData(OFF_HAND_IDLE_ANIMATION_TYPE);
+    }
+
+    public static void setMainHandIdleAnimation(PlayerEntity player, String animation) {
+        player.setData(MAIN_HAND_IDLE_ANIMATION_TYPE, animation);
+    }
+
+    public static void setOffHandIdleAnimation(PlayerEntity player, String animation) {
+        player.setData(OFF_HAND_IDLE_ANIMATION_TYPE, animation);
+    }
+}
+


### PR DESCRIPTION
As a rule, it seems appending `TrackedData`/`SynchedEntityData` onto other entities via mixin is a bad idea as it can cause unexpected collisions (Like #524) 

This PR migrates the Idle Animation tracked data appended in `PlayerEntityMixin` to instead use platform-specific Data Attachments: **Fabric Data Attachment API** and **Neoforge Attachments**.

All new attachments, matching the old `TrackedData` behavior:
- Automatically sync to self and nearby players
- Do not serialize/save to disk
 
Definitively Fixes #524 (Tested in MMC5 Neoforge Modpack on dedicated server with CarryOn) 

### Important consideration: 
1. Fabric Data Attachment API is still mostly marked with ApiStatus Experimental (Hence `FabricPlayerAttachment`'s usages of `@SuppressWarnings("UnstableApiUsage")`

### Less important considerations:
2. Organization of this PR: `PlayerAttachments` being in the root project dir seems unfitting, but I'm pretty unfamiliar with Architectury's ExpectPlatform and unsure how you'd like to organize this. Feel free to suggest moving anything around. 
3. I did not change your modified Mixin Priority for `PlayerEntityMixin` from https://github.com/ZsoltMolnarrr/BetterCombat/commit/363b2dcf1e60f5eed0f70e04c4440ebbadc10dd5 
4. It also seems like many of `PlayerEntityMixin`'s non-mixin members should be annotated with `@Unique`. I didn't change this either.
5. Also includes bumping Fabric + Fabric API + Neoforge, necessary to use latest Data Attachment APIs


